### PR TITLE
Fix broken cask syntax

### DIFF
--- a/Casks/synergy.rb
+++ b/Casks/synergy.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'synergy' do
+cask 'synergy' do
   version '1.6.2'
   sha256 '259dd8367e0d9b6152e93d50854687d54714f649b6b018949621ba2194b3f987'
 


### PR DESCRIPTION
```
Error: calling "cask :v1 => 'token'" os disabled! Use "cask 'token'" instead.
Please report this to the agnoster/synergykm tap, or even better, submit a PR to fix it:
```